### PR TITLE
chore/docs: interactive menus + enforce user story format/persona; README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,33 @@ A spec‑first, prompt‑only workflow that turns product specs into determinist
 3) No GitHub? Everything still works locally; Integrator records a shadow ID.
 4) On GitHub? Use the optional PR flags in `AGENTS.md` or run `07_pr_creator.md` to open a ready‑for‑review PR with an auto‑generated description.
 
+## Interactive Mode Menus
+Agents run with zero parameters but now start with a small, first‑turn menu to make intent explicit. If you provide no selection, they default to the first option.
+
+- StoryPlanner
+  - New story (default)
+  - Update existing story
+  - Merge stories
+  - Bootstrap from scratch
+  - Scan codebase and propose stories (non‑destructive; writes `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft stories)
+  - Cancel
+
+- ArchitectPlanner
+  - Make design ready (default)
+  - Update components & interfaces
+  - Update dependency policy
+  - Update quality budgets
+  - Generate/refresh API contracts
+  - Analyze and list open questions (log‑only)
+  - Cancel
+
+- TaskPlanner
+  - Plan tasks for eligible stories (default)
+  - Regenerate tasks for specific stories
+  - Supersede stale tasks only
+  - Rebuild derived list only
+  - Cancel
+
 ## Common Use Cases
 - New feature: Plan stories/design → generate small tasks → TDD via Builder → test/review/integrate.
 - Existing codebase, add specs: Backfill stories/design; TaskPlanner creates focused tasks; Reviewer catches orphan diffs.

--- a/demo_repo/README.md
+++ b/demo_repo/README.md
@@ -12,3 +12,10 @@ Selection invariants (no parameters):
 1) Latest NEXT in `.codex/runs/*` if still valid
 2) Else first eligible by priority (P0→P3), then id asc, then oldest mtime
 3) Else print INFO and exit
+
+## Interactive Menus
+Agents now open with a small first-turn menu (zero parameters). Defaults to the first option.
+
+- StoryPlanner: New story, Update, Merge, Bootstrap, Scan/propose, Cancel
+- ArchitectPlanner: Make ready, Update components/interfaces, Update policy, Update budgets, Contracts, Analyze questions, Cancel
+- TaskPlanner: Plan eligible, Regenerate specific, Supersede only, Rebuild list, Cancel

--- a/user_dot_codex/prompts/00_storyplanner.md
+++ b/user_dot_codex/prompts/00_storyplanner.md
@@ -8,27 +8,63 @@ Seed or augment project specs from feature needs; bootstrap `.codex/*`.
 - Do NOT copy schemas into project. Render outputs using schema paths from AGENTS.md.
 
 ## Inputs
-- Interactive Q&A or a feature file path (PRD/bullets).
+- Interactive menu + Q&A, or a feature file path (PRD/bullets).
 - User/Project AGENTS.md for conventions and schema paths.
 
 ## Selection
 Resolve target using Selection precedence (NEXT → eligible set → INFO).
 
+## Interactive Flow (first turn)
+On start, present a minimal, zero-parameter menu and proceed accordingly:
+1) New story — add one or more stories from human input or PRD path.
+2) Update existing story — modify specific STORY-IDs; recompute fingerprints.
+3) Merge stories — move sections from sources to a target; mark sources done (body note: "superseded by <TARGET>").
+4) Bootstrap from scratch — if specs missing/empty, scaffold `01.requirements.md` and `02.design.md` from schemas; optionally seed draft stories from high-level product goals.
+5) Scan codebase and propose stories — non-destructive heuristic scan of `src/**` and `tests/**`; write proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft stories (status=draft) for human review.
+6) Cancel — exit with `INFO: user cancelled`.
+
+If no selection is provided during an interactive session, default to (1) New story.
+
+## Modes & Behavior
+- New story
+  - Create vertical user stories in `.codex/spec/01.requirements.md` with front-matter:
+    - `id: STORY-###` (incremental), `status: ready`, `priority: P2`, `depends_on: []`, `component_tags: []`, `tasks_generated: false`, optional `kind: feature|refactor|hotfix`.
+  - Sections: Motivation, Acceptance (testable bullets), NFR, Out of Scope (optional).
+  - Compute and set `story_fingerprint`.
+  - Dedupe by normalized title to avoid duplicates.
+- Update story
+  - Require explicit `STORY-IDs` and updated fields/sections.
+  - Edit content; recompute `story_fingerprint` for each updated story.
+  - Do not modify unrelated stories.
+- Merge stories
+  - Require a target `STORY-ID` and one or more source `STORY-IDs`.
+  - Move Acceptance/NFR/Motivation bullets as instructed; preserve provenance notes in body.
+  - Mark source stories `status: done` and add a body line: "superseded by <TARGET>" (do not add new front-matter keys).
+  - Recompute fingerprints on affected stories.
+- Bootstrap from scratch
+  - If `.codex/spec` is missing or empty, render `01.requirements.md` and `02.design.md` from schemas.
+  - Optionally seed a minimal set of draft stories from high-level goals. Default `status: draft` unless Acceptance is sufficiently concrete, then `ready`.
+- Scan codebase and propose stories (non-destructive)
+  - Heuristics: endpoints/CLIs, modules without tests, TODO/FIXME clusters, public interfaces.
+  - Output proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft story blocks; do not set to `ready` automatically.
+
 ## Steps
-1) Intake features; produce vertical user stories with:
-   - id: STORY-### (incremental), status=ready, priority=P2, depends_on=[], component_tags=[], tasks_generated=false
-   - sections: Motivation, Acceptance (testable bullets), NFR, Out of Scope (optional)
-   - compute story_fingerprint
-   - Hotfix note: when the feature is a hotfix, set `kind: hotfix` and consider defaulting priority to P0.
-2) Ensure `.codex/spec/02.design.md` exists; if missing, render from design schema with status=draft.
-3) Append stories to `.codex/spec/01.requirements.md` (dedupe on normalized title).
-4) Write run log `.codex/runs/<ts>/storyplanner.md`.
+1) Execute the selected mode. For story writes, append/update in `.codex/spec/01.requirements.md` with dedupe and `story_fingerprint` computed.
+2) Ensure `.codex/spec/02.design.md` exists; if missing, render from design schema with `status: draft`.
+3) Write run log `.codex/runs/<ts>/storyplanner.md` summarizing actions and decisions.
+
+## Safety & Guardrails
+- Never edit `.codex/spec/03.tasks.md` directly (derived by planners).
+- Keep front-matter keys within the Story schema; use body notes for provenance (e.g., superseded-by) rather than new keys.
+- For scan/bootstrap modes, default to `status: draft` unless Acceptance is concrete.
+- Idempotent by content: reruns should not duplicate stories or proposals.
 
 ## Output
-- `.codex/spec/01.requirements.md` (stories)
-- `.codex/spec/02.design.md` (if missing)
-- run log only
+- `.codex/spec/01.requirements.md` (stories updated/appended as applicable)
+- `.codex/spec/02.design.md` (ensured; created if missing)
+- `.codex/runs/<ts>/story_backfill_proposals.md` (scan mode only)
+- Run log only
 
 ## NEXT
-- If any story is ready: NEXT: run ArchitectPlanner (01_architectplanner.md)
-- Else: INFO: no actionable features
+- If any story is `ready`: `NEXT: run ArchitectPlanner (01_architectplanner.md)`
+- Else: `INFO: no actionable features`

--- a/user_dot_codex/prompts/02_taskplanner.md
+++ b/user_dot_codex/prompts/02_taskplanner.md
@@ -12,16 +12,39 @@ Turn eligible stories into 1–3 small tasks each; tests-first.
 ## Selection
 Resolve target using Selection precedence (NEXT → eligible set → INFO).
 
+## Interactive Flow (first turn)
+Offer a small menu; default to (1) if no selection is given:
+1) Plan tasks for eligible stories — create tasks where `tasks_generated=false` or fingerprints drift.
+2) Regenerate tasks for specific stories — force supersede then recreate tasks for given STORY-IDs.
+3) Supersede stale tasks only — mark stale tasks superseded without creating new ones.
+4) Rebuild derived list only — refresh `.codex/spec/03.tasks.md` from current tasks.
+5) Cancel — exit with `INFO: user cancelled`.
+
+## Modes & Behavior
+- Plan tasks for eligible stories (default)
+  - For each selected story, create 1–3 focused tasks with `status: ready`, inheriting story `priority` and mapping to a single `component` where possible.
+  - Embed `story_fingerprint` and `design_fingerprint` into each task; set `story.tasks_generated=true` and `story.status=planned` if newly planned.
+- Regenerate tasks for specific stories
+  - Identify existing tasks for those stories; mark `ready|needs_update` ones as `superseded` and set `superseded_by` to the new tasks.
+  - Recreate tasks fresh from current specs; maintain small, testable scope.
+- Supersede stale tasks only
+  - Detect fingerprint drift and set affected tasks to `needs_update` or `superseded` per policy; do not create new tasks.
+- Rebuild derived list only
+  - Leave tasks untouched; render `.codex/spec/03.tasks.md` from `.codex/tasks/*.md`.
+
 ## Steps
-1) Select stories with tasks_generated=false or with stale tasks by fingerprint.
-   - Selection order: priority P0→P3, then STORY-ID asc; tie-breaker: oldest `last_modified_ts`.
-2) For the selected story:
-   - Supersede stale `ready/needs_update` tasks: set `status: superseded` and link `superseded_by`.
-   - Render `.codex/tasks/TASK-###.md` from task schema; set status=ready; inherit priority; set story/design fingerprints.
-   - Set story.tasks_generated=true and, if newly planned, story.status=planned.
-   - Hotfix note: if `story.kind=hotfix`, prefer a single focused task (priority typically P0) to expedite the fix.
+1) Select stories per policy: `tasks_generated=false` or fingerprint drift.
+   - Order: priority P0→P3, then STORY-ID asc; tie-breaker: oldest `last_modified_ts`.
+2) Execute chosen mode for each selected story, keeping 1–3 tasks max per story and ensuring each task is independently testable.
+   - For hotfix stories (`kind: hotfix`), prefer a single, focused task (often P0).
 3) Render `.codex/spec/03.tasks.md` from tasks_list_view schema (derived from files).
-4) Log `.codex/runs/<ts>/taskplanner.md`.
+4) Log `.codex/runs/<ts>/taskplanner.md` with created/superseded tasks and any drift rationale.
+
+## Safety & Guardrails
+- Edit only `.codex/tasks/**` and derived `.codex/spec/03.tasks.md`; do not touch `src/**` or `tests/**`.
+- Do not hand-edit `03.tasks.md`; always regenerate from task files.
+- Maintain idempotency: reruns should not duplicate tasks; supersedes must link via `superseded_by`.
+- Refuse to generate tasks if `design.status != ready`.
 
 ## Output
 - New/updated `.codex/tasks/*.md`


### PR DESCRIPTION
Summary
- Add first-turn interactive mode menus to StoryPlanner, ArchitectPlanner, and TaskPlanner prompts.
- Document menus in top-level README and demo_repo README.

Details
- StoryPlanner: New, Update, Merge, Bootstrap, Scan/propose, Cancel; adds guardrails and explicit outputs/NEXT.
- ArchitectPlanner: Make ready, Update components/interfaces, Update dependency policy, Update quality budgets, Generate/refresh contracts, Analyze questions, Cancel; adds guardrails.
- TaskPlanner: Plan eligible, Regenerate specific, Supersede only, Rebuild list, Cancel; adds guardrails.

Motivation
- Improve zero-parameter UX by making agent intent explicit without flags, preserving determinism and idempotency.

Testing
- Manual review of prompt files; no code path changes in demo app. Safe, prompt-only edits.

Changelog
- chore: interactive menus for Story/Architect/Task planners; README updates
\nUpdates (Story Format)
- Enforce user story format (As… I want… so that…) and Persona section in schema/prompt/spec.
- Added README guidance for required story format.
