### PR TITLE
demo: update design for CSV export; align task fingerprints

### DIFF
--- a/demo_repo/.codex/spec/02.design.md
+++ b/demo_repo/.codex/spec/02.design.md
@@ -1,14 +1,14 @@
 # System Design
 ---
 status: ready
-design_fingerprint: "sha256:20ac8619173d9f92645a468e7d63e3e7c92fac501b98df3a606ff15d212465cb"
+design_fingerprint: "sha256:2ff2b48a932e4e0e3b5b586426e8d72dfda7de9b3fcef706379c6ba4eaeb1892"
 quality_budgets:
   api_p95_ms: 200
   web_ttfb_ms: 300
 dependency_policy:
-  allowed: {'api': ['auth'], 'auth': ['db', 'notify']}
+  allowed: {'api': ['auth', 'reporting'], 'auth': ['db', 'notify'], 'reporting': ['db']} 
   forbidden: ['web->db']
-components: [{'id': 'auth', 'owner': 'TBD', 'public_interfaces': []}, {'id': 'api', 'owner': 'TBD', 'public_interfaces': ['POST /v1/auth/reset']}, {'id': 'notify', 'owner': 'TBD', 'public_interfaces': []}, {'id': 'db', 'owner': 'TBD', 'public_interfaces': []}]
+components: [{'id': 'auth', 'owner': 'TBD', 'public_interfaces': []}, {'id': 'api', 'owner': 'TBD', 'public_interfaces': ['POST /v1/auth/reset', 'GET /v1/reports/{id}/export']}, {'id': 'notify', 'owner': 'TBD', 'public_interfaces': []}, {'id': 'db', 'owner': 'TBD', 'public_interfaces': []}, {'id': 'reporting', 'owner': 'TBD', 'public_interfaces': []}]
 ---
 ## Context
-Implements password reset request endpoint in API, delegating to auth; notifies mailer.
+Implements password reset and CSV export: API exposes POST /v1/auth/reset and GET /v1/reports/{id}/export; reporting handles CSV generation; auth/db/notify as before.

--- a/demo_repo/.codex/tasks/TASK-002.md
+++ b/demo_repo/.codex/tasks/TASK-002.md
@@ -8,7 +8,7 @@ component: api
 artifacts: ['src/api/reports_export.py', 'tests/api/test_reports_export.py']
 assignee: null
 story_fingerprint: "sha256:4e6875acfa96dfb5f3a6a030a1b7fb3b01b9d92737d2c24fee589fe3a3e1c5a6"
-design_fingerprint: "sha256:20ac8619173d9f92645a468e7d63e3e7c92fac501b98df3a606ff15d212465cb"
+design_fingerprint: "sha256:2ff2b48a932e4e0e3b5b586426e8d72dfda7de9b3fcef706379c6ba4eaeb1892"
 superseded_by: null
 artifact_fingerprints: {}
 review_baseline_sha: ""
@@ -27,4 +27,3 @@ Add GET /v1/reports/{id}/export?format=csv endpoint: validate params, enforce ro
 
 ### Rollback
 git revert <commit or shadow>; no schema changes.
-

--- a/demo_repo/.codex/tasks/TASK-003.md
+++ b/demo_repo/.codex/tasks/TASK-003.md
@@ -8,7 +8,7 @@ component: reporting
 artifacts: ['src/reporting/csv_export.py', 'tests/reporting/test_csv_export.py']
 assignee: null
 story_fingerprint: "sha256:4e6875acfa96dfb5f3a6a030a1b7fb3b01b9d92737d2c24fee589fe3a3e1c5a6"
-design_fingerprint: "sha256:20ac8619173d9f92645a468e7d63e3e7c92fac501b98df3a606ff15d212465cb"
+design_fingerprint: "sha256:2ff2b48a932e4e0e3b5b586426e8d72dfda7de9b3fcef706379c6ba4eaeb1892"
 superseded_by: null
 artifact_fingerprints: {}
 review_baseline_sha: ""
@@ -26,4 +26,3 @@ Implement CSV generation for reports: header row, UTF-8 encoding, quoting, row l
 
 ### Rollback
 git revert <commit or shadow>; no schema changes.
-


### PR DESCRIPTION
Summary
- Add first-turn interactive mode menus to StoryPlanner, ArchitectPlanner, and TaskPlanner prompts.
- Document menus in top-level README and demo_repo README.

Details
- StoryPlanner: New, Update, Merge, Bootstrap, Scan/propose, Cancel; adds guardrails and explicit outputs/NEXT.
- ArchitectPlanner: Make ready, Update components/interfaces, Update dependency policy, Update quality budgets, Generate/refresh contracts, Analyze questions, Cancel; adds guardrails.
- TaskPlanner: Plan eligible, Regenerate specific, Supersede only, Rebuild list, Cancel; adds guardrails.

Motivation
- Improve zero-parameter UX by making agent intent explicit without flags, preserving determinism and idempotency.

Testing
- Manual review of prompt files; no code path changes in demo app. Safe, prompt-only edits.

Changelog
- chore: interactive menus for Story/Architect/Task planners; README updates
\nUpdates (Story Format)
- Enforce user story format (As… I want… so that…) and Persona section in schema/prompt/spec.
- Added README guidance for required story format.
\nPersona-first StoryPlanner
- Introduce optional Persona Catalog (00.personas.md) and template.
- Story schema now references persona by name; persona details live in catalog.
- StoryPlanner flow: persona check → outcome framing → user story → AC → NFR → scope → dedupe → hints → status/fingerprints.
\nPersona matching examples & demo catalog
- Documented matching algorithm and examples in StoryPlanner prompt.
- Seeded demo_repo/.codex/spec/00.personas.md with two personas for trial runs.
\nPersona-aware Planner Updates
- ArchitectPlanner: budgets/interfaces/policy checks informed by persona; open questions instead of guessing.
- TaskPlanner: map acceptance categories to tasks/tests; ensure permission coverage and component sanity.
\nDemo updates
- Added STORY-002 (Export CSV) and two ready tasks (API endpoint, CSV generation).
- Refreshed derived tasks list in demo to show the new tasks.
\nGlobal AGENTS.md updates
- Add Agent Tooling Convention: put helper tools under .codex/tools/** and invoke via relative path.
- Define folder conventions for src/tests/scripts; update builder guardrails to include .codex/tools/**.
