### PR TITLE
docs: persona-first StoryPlanner, ArchitecturePlanner rename, planner menus, Product Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Codex Agentic Framework — v1g4
+# Codex Agentic Framework
 
 A spec‑first, prompt‑only workflow that turns product specs into deterministic coding loops — no servers, no hidden state. Agents are stateless and run with zero parameters.
 

--- a/demo_repo/.codex/spec/01.requirements.md
+++ b/demo_repo/.codex/spec/01.requirements.md
@@ -1,5 +1,8 @@
 # Requirements
 
+## Product Vision
+Provide a minimal API-driven service that enables core auth flows and simple reporting exports for our primary personas (Data Analyst, Support Agent), focusing on speed, reliability, and clear observability.
+
 ## STORY-001 — Password Reset via Email
 ---
 id: STORY-001

--- a/spec_driven_codex_agentic_framework_end_to_end_design_v_1.md
+++ b/spec_driven_codex_agentic_framework_end_to_end_design_v_1.md
@@ -112,6 +112,7 @@ Structure: one section per persona with the following fields.
 If absent, stories may include inline Persona sections; StoryPlanner can propose catalog entries in `.codex/runs/<ts>/persona_proposals.md`.
 
 ### 3.1 Story (blocks inside `01.requirements.md`)
+`01.requirements.md` begins with a single-paragraph **Product Vision** summary (purpose, target personas, primary goals), followed by one or more story blocks.
 ```yaml
 id: STORY-012
 type: story
@@ -205,6 +206,10 @@ Human‑readable backlog (checkbox list), rebuilt from `.codex/tasks/*.md` — *
 - **Scan mode**: heuristically mine code/tests/TODOs to draft candidates; write proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and inline draft stories only if explicitly approved.
 - **Outputs**: `01.requirements.md` updated; optional proposals under `.codex/runs/<ts>/*proposals.md`; ensure `02.design.md` exists (`status=draft` if new); run log.
 - **NEXT**: `ArchitectPlanner` if any story is `ready`; else `INFO`.
+
+StoryPlanner also manages the Product Vision paragraph:
+- On bootstrap or when explicitly selected, it inserts/edits a single-paragraph vision at the top of `01.requirements.md` below the main header.
+- This section is not fingerprinted per story; it is informational and should remain concise and stable.
 
 ### 5.2 ArchitectPlanner (`01_architectplanner.md`)
 **Role**: Make design **ready** (components, interfaces, budgets, dependency policy).

--- a/user_dot_codex/prompts/00_storyplanner.md
+++ b/user_dot_codex/prompts/00_storyplanner.md
@@ -20,9 +20,10 @@ On start, present a minimal, zero-parameter menu and proceed accordingly:
 1) New story — add one or more stories from human input or PRD path.
 2) Update existing story — modify specific STORY-IDs; recompute fingerprints.
 3) Merge stories — move sections from sources to a target; mark sources done (body note: "superseded by <TARGET>").
-4) Bootstrap from scratch — if specs missing/empty, scaffold `01.requirements.md` and `02.design.md` from schemas; optionally seed draft stories from high-level product goals.
-5) Scan codebase and propose stories — non-destructive heuristic scan of `src/**` and `tests/**`; write proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft stories (status=draft) for human review.
-6) Cancel — exit with `INFO: user cancelled`.
+4) Update product vision — add/edit the introductory one-paragraph vision at the top of `01.requirements.md`.
+5) Bootstrap from scratch — if specs missing/empty, scaffold `01.requirements.md` and `02.design.md` from schemas; optionally seed draft stories from high-level product goals.
+6) Scan codebase and propose stories — non-destructive heuristic scan of `src/**` and `tests/**`; write proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft stories (status=draft) for human review.
+7) Cancel — exit with `INFO: user cancelled`.
 
 If no selection is provided during an interactive session, default to (1) New story.
 
@@ -55,6 +56,10 @@ If no selection is provided during an interactive session, default to (1) New st
 - Bootstrap from scratch
   - If `.codex/spec` is missing or empty, render `01.requirements.md` and `02.design.md` from schemas.
   - Optionally seed a minimal set of draft stories from high-level goals. Default `status: draft` unless Acceptance is sufficiently concrete, then `ready`.
+- Update product vision
+  - Ensure `01.requirements.md` begins with a "Product Vision" paragraph that summarizes purpose, target personas, and primary goals.
+  - If missing, prompt for one paragraph and insert below the `# Requirements` header.
+  - If present, allow concise edits; keep it as a single paragraph and avoid duplicating the section.
 - Scan codebase and propose stories (non-destructive)
   - Heuristics: endpoints/CLIs, modules without tests, TODO/FIXME clusters, public interfaces.
   - Output proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft story blocks; do not set to `ready` automatically.

--- a/user_dot_codex/schemas/requirements.template.md
+++ b/user_dot_codex/schemas/requirements.template.md
@@ -1,5 +1,8 @@
 # Requirements
 
+## Product Vision
+<one-paragraph summary of the product's purpose, target personas, and primary goals>
+
 ## STORY-001 — <title>
 ---
 id: STORY-001


### PR DESCRIPTION
Summary
- Add first-turn interactive mode menus to StoryPlanner, ArchitectPlanner, and TaskPlanner prompts.
- Document menus in top-level README and demo_repo README.

Details
- StoryPlanner: New, Update, Merge, Bootstrap, Scan/propose, Cancel; adds guardrails and explicit outputs/NEXT.
- ArchitectPlanner: Make ready, Update components/interfaces, Update dependency policy, Update quality budgets, Generate/refresh contracts, Analyze questions, Cancel; adds guardrails.
- TaskPlanner: Plan eligible, Regenerate specific, Supersede only, Rebuild list, Cancel; adds guardrails.

Motivation
- Improve zero-parameter UX by making agent intent explicit without flags, preserving determinism and idempotency.

Testing
- Manual review of prompt files; no code path changes in demo app. Safe, prompt-only edits.

Changelog
- chore: interactive menus for Story/Architect/Task planners; README updates
\nUpdates (Story Format)
- Enforce user story format (As… I want… so that…) and Persona section in schema/prompt/spec.
- Added README guidance for required story format.
\nPersona-first StoryPlanner
- Introduce optional Persona Catalog (00.personas.md) and template.
- Story schema now references persona by name; persona details live in catalog.
- StoryPlanner flow: persona check → outcome framing → user story → AC → NFR → scope → dedupe → hints → status/fingerprints.
\nPersona matching examples & demo catalog
- Documented matching algorithm and examples in StoryPlanner prompt.
- Seeded demo_repo/.codex/spec/00.personas.md with two personas for trial runs.
\nPersona-aware Planner Updates
- ArchitectPlanner: budgets/interfaces/policy checks informed by persona; open questions instead of guessing.
- TaskPlanner: map acceptance categories to tasks/tests; ensure permission coverage and component sanity.
\nDemo updates
- Added STORY-002 (Export CSV) and two ready tasks (API endpoint, CSV generation).
- Refreshed derived tasks list in demo to show the new tasks.
\nGlobal AGENTS.md updates
- Add Agent Tooling Convention: put helper tools under .codex/tools/** and invoke via relative path.
- Define folder conventions for src/tests/scripts; update builder guardrails to include .codex/tools/**.
\nProduct Vision
- Add single-paragraph Product Vision at top of requirements: template, spec, and StoryPlanner support; demo seeded.
\nRename + Logic
- Rename ArchitectPlanner → ArchitecturePlanner across prompts/docs.
- ArchitecturePlanner now prioritizes ready/planned stories but includes drafts to raise Open Questions; StoryPlanner still NEXTs when any story is ready.
