### PR TITLE
docs: persona-first StoryPlanner, ArchitecturePlanner rename, planner menus, Product Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A spec‑first, prompt‑only workflow that turns product specs into determinist
 ## What’s Inside
 - User‑level defaults under `user_dot_codex/` (copy to `~/.codex/`):
   - `AGENTS.md` — policies, selection rules, guardrails
-  - `prompts/00..06` — StoryPlanner → Integrator agent prompts
+- `prompts/00..06` — StoryPlanner → Integrator agent prompts
   - `prompts/07_pr_creator.md` — optional PR creation utility (GitHub CLI)
   - `schemas/` — story, design, task, derived list templates, and a personas catalog template
 - A minimal `demo_repo/` showing the full loop with local‑only “shadow lineage”.
@@ -21,7 +21,7 @@ A spec‑first, prompt‑only workflow that turns product specs into determinist
 ## Quick Start
 1) Copy `user_dot_codex/` → `~/.codex/`.
 2) In your project, run agents in order or jump in anywhere:
-   - StoryPlanner → ArchitectPlanner → TaskPlanner → Builder → Tester → Reviewer → Integrator
+   - StoryPlanner → ArchitecturePlanner → TaskPlanner → Builder → Tester → Reviewer → Integrator
 3) No GitHub? Everything still works locally; Integrator records a shadow ID.
 4) On GitHub? Use the optional PR flags in `AGENTS.md` or run `07_pr_creator.md` to open a ready‑for‑review PR with an auto‑generated description.
 
@@ -36,7 +36,7 @@ Agents run with zero parameters but now start with a small, first‑turn menu to
   - Scan codebase and propose stories (non‑destructive; writes `.codex/runs/<ts>/story_backfill_proposals.md` and/or draft stories)
   - Cancel
 
-- ArchitectPlanner
+- ArchitecturePlanner
   - Make design ready (default)
   - Update components & interfaces
   - Update dependency policy

--- a/demo_repo/README.md
+++ b/demo_repo/README.md
@@ -17,5 +17,5 @@ Selection invariants (no parameters):
 Agents now open with a small first-turn menu (zero parameters). Defaults to the first option.
 
 - StoryPlanner: New story, Update, Merge, Bootstrap, Scan/propose, Cancel
-- ArchitectPlanner: Make ready, Update components/interfaces, Update policy, Update budgets, Contracts, Analyze questions, Cancel
+- ArchitecturePlanner: Make ready, Update components/interfaces, Update policy, Update budgets, Contracts, Analyze questions, Cancel
 - TaskPlanner: Plan eligible, Regenerate specific, Supersede only, Rebuild list, Cancel

--- a/spec_driven_codex_agentic_framework_end_to_end_design_v_1.md
+++ b/spec_driven_codex_agentic_framework_end_to_end_design_v_1.md
@@ -44,7 +44,7 @@ repo/
 
 ### 2.1 Agent registry
 - StoryPlanner: `00_storyplanner.md`
-- ArchitectPlanner: `01_architectplanner.md`
+- ArchitecturePlanner: `01_architectureplanner.md`
 - TaskPlanner: `02_taskplanner.md`
 - Builder: `03_builder.md`
 - Tester: `04_tester.md`
@@ -205,16 +205,16 @@ Human‑readable backlog (checkbox list), rebuilt from `.codex/tasks/*.md` — *
 - **Bootstrap mode**: if specs are missing/empty, scaffold `01.requirements.md` and `02.design.md`; seed draft stories from PRD; prompt for persona selection; prefer `status=draft`.
 - **Scan mode**: heuristically mine code/tests/TODOs to draft candidates; write proposals to `.codex/runs/<ts>/story_backfill_proposals.md` and inline draft stories only if explicitly approved.
 - **Outputs**: `01.requirements.md` updated; optional proposals under `.codex/runs/<ts>/*proposals.md`; ensure `02.design.md` exists (`status=draft` if new); run log.
-- **NEXT**: `ArchitectPlanner` if any story is `ready`; else `INFO`.
+- **NEXT**: `ArchitecturePlanner` if any story is `ready`; else `INFO`.
 
 StoryPlanner also manages the Product Vision paragraph:
 - On bootstrap or when explicitly selected, it inserts/edits a single-paragraph vision at the top of `01.requirements.md` below the main header.
 - This section is not fingerprinted per story; it is informational and should remain concise and stable.
 
-### 5.2 ArchitectPlanner (`01_architectplanner.md`)
+### 5.2 ArchitecturePlanner (`01_architectureplanner.md`)
 **Role**: Make design **ready** (components, interfaces, budgets, dependency policy).
 
-- **Preflight**: recompute `design_fingerprint`; ensure components/interfaces exist for `ready|planned` stories; update budgets/policy.
+- **Preflight**: recompute `design_fingerprint`; ensure components/interfaces exist for stories (prioritize `ready|planned`; include `draft` to raise Open Questions); update budgets/policy.
 - **Steps**: normalize `component_tags` → add/adjust public interfaces → update `dependency_policy`/budgets → set `status=ready` if prerequisites satisfied; else keep `draft` + Open Questions. Log.
 - **Output**: updated `02.design.md`, optional `contracts/openapi.yaml`, run log.
 - **NEXT**: `TaskPlanner` if `design=ready`; else `BLOCKED` with questions.
@@ -308,12 +308,12 @@ StoryPlanner also manages the Product Vision paragraph:
 
 | Scenario | Supported Path |
 |---|---|
-| **New feature** | StoryPlanner → ArchitectPlanner → TaskPlanner → Builder → Tester → Reviewer → Integrator |
+| **New feature** | StoryPlanner → ArchitecturePlanner → TaskPlanner → Builder → Tester → Reviewer → Integrator |
 | **Modify feature via Codex/spec** | Edit story/design → fingerprints drift → TaskPlanner supersedes → Builder refuses stale → normal flow |
 | **Manual spec edits** | Same as above; self‑heals via fingerprints |
 | **Manual code edits (no task)** | Reviewer auto‑creates **retrofit task**; blocks until built/tested/integrated |
 | **Add new source files** | Treated as orphan diff → retrofit task |
-| **Hotfix** | `story.kind=hotfix`, P0, one‑task flow; ArchitectPlanner can backfill later |
+| **Hotfix** | `story.kind=hotfix`, P0, one‑task flow; ArchitecturePlanner can backfill later |
 | **Parallel work** | Deterministic selection (priority,id,age) prevents ambiguity; small PRs limit risk |
 | **Reruns/new sessions** | Stateless agents read specs/tasks/logs; consistent via selection precedence |
 | **No GitHub / no commits** | Full loop works locally; Integrator records **shadow lineage** and flips statuses |

--- a/user_dot_codex/AGENTS.md
+++ b/user_dot_codex/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Agent Registry
 - StoryPlanner: 00_storyplanner.md
-- ArchitectPlanner: 01_architectplanner.md
+- ArchitecturePlanner: 01_architectureplanner.md
 - TaskPlanner: 02_taskplanner.md
 - Builder: 03_builder.md
 - Tester: 04_tester.md

--- a/user_dot_codex/prompts/00_storyplanner.md
+++ b/user_dot_codex/prompts/00_storyplanner.md
@@ -97,5 +97,5 @@ If no selection is provided during an interactive session, default to (1) New st
 - Run log only
 
 ## NEXT
-- If any story is `ready`: `NEXT: run ArchitectPlanner (01_architectplanner.md)`
+- If any story is `ready`: `NEXT: run ArchitecturePlanner (01_architectureplanner.md)`
 - Else: `INFO: no actionable features`

--- a/user_dot_codex/prompts/01_architectureplanner.md
+++ b/user_dot_codex/prompts/01_architectureplanner.md
@@ -1,4 +1,4 @@
-# 01_architectplanner — ArchitectPlanner
+# 01_architectureplanner — ArchitecturePlanner
 
 ## Goal
 Make the design ready: components, interfaces, dependency policy, quality budgets.
@@ -24,7 +24,7 @@ Present a lightweight menu; default to (1) if no selection is given:
 ## Modes & Behavior
 - Make design ready (default)
   - Normalize `components` and their `public_interfaces` based on `component_tags` and story references.
-  - Ensure `dependency_policy` and `quality_budgets` exist and are sensible for current stories.
+  - Ensure `dependency_policy` and `quality_budgets` exist and are sensible for current stories (prioritize ready/planned; include drafts for Open Questions).
   - Recompute `design_fingerprint`; set `status: ready` if prerequisites are met; otherwise keep `draft` and list open questions.
 - Update components & interfaces
   - Apply requested adds/renames/merges and interface updates; preserve stable component IDs where possible.


### PR DESCRIPTION
Summary
- Add first-turn interactive mode menus to StoryPlanner, ArchitectPlanner, and TaskPlanner prompts.
- Document menus in top-level README and demo_repo README.

Details
- StoryPlanner: New, Update, Merge, Bootstrap, Scan/propose, Cancel; adds guardrails and explicit outputs/NEXT.
- ArchitectPlanner: Make ready, Update components/interfaces, Update dependency policy, Update quality budgets, Generate/refresh contracts, Analyze questions, Cancel; adds guardrails.
- TaskPlanner: Plan eligible, Regenerate specific, Supersede only, Rebuild list, Cancel; adds guardrails.

Motivation
- Improve zero-parameter UX by making agent intent explicit without flags, preserving determinism and idempotency.

Testing
- Manual review of prompt files; no code path changes in demo app. Safe, prompt-only edits.

Changelog
- chore: interactive menus for Story/Architect/Task planners; README updates
\nUpdates (Story Format)
- Enforce user story format (As… I want… so that…) and Persona section in schema/prompt/spec.
- Added README guidance for required story format.
\nPersona-first StoryPlanner
- Introduce optional Persona Catalog (00.personas.md) and template.
- Story schema now references persona by name; persona details live in catalog.
- StoryPlanner flow: persona check → outcome framing → user story → AC → NFR → scope → dedupe → hints → status/fingerprints.
\nPersona matching examples & demo catalog
- Documented matching algorithm and examples in StoryPlanner prompt.
- Seeded demo_repo/.codex/spec/00.personas.md with two personas for trial runs.
\nPersona-aware Planner Updates
- ArchitectPlanner: budgets/interfaces/policy checks informed by persona; open questions instead of guessing.
- TaskPlanner: map acceptance categories to tasks/tests; ensure permission coverage and component sanity.
\nDemo updates
- Added STORY-002 (Export CSV) and two ready tasks (API endpoint, CSV generation).
- Refreshed derived tasks list in demo to show the new tasks.
\nGlobal AGENTS.md updates
- Add Agent Tooling Convention: put helper tools under .codex/tools/** and invoke via relative path.
- Define folder conventions for src/tests/scripts; update builder guardrails to include .codex/tools/**.
\nProduct Vision
- Add single-paragraph Product Vision at top of requirements: template, spec, and StoryPlanner support; demo seeded.
\nRename + Logic
- Rename ArchitectPlanner → ArchitecturePlanner across prompts/docs.
- ArchitecturePlanner now prioritizes ready/planned stories but includes drafts to raise Open Questions; StoryPlanner still NEXTs when any story is ready.
